### PR TITLE
Improve spring integration and provide spring boot example

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ public class HelloWorldTest {
 }
 ```
 
-The report will be written to `zuchini-report.json` in a [format described by json schema](zuchini-reporter/schema.json).
+The report will be written to `zuchini-report.json` in a [format described by this json schema](zuchini-reporter/schema.json).
 
 **Note**: The report format differs from the format used by cucumber-jvm and therefore cannot be interpreted by the usual report generation plugins.
 
@@ -149,19 +149,30 @@ public class CukesSpringTest {
 }
 ```
 
-The `ScenarioScopeConfiguration` defines a spring scope per executed scenario that you can use on your step definition classes, so that a new instance is instanciated by spring for each scenario:
+The `ScenarioScopeConfiguration` defines a spring scope per executed scenario that you can use on your step definition classes, so that a new instance is instantiated by spring for each scenario:
 
 ```java
 @Component
 @ScenarioScoped
-public class HelloWorldSteps {
+public class HelloSpringSteps {
 }
 ```
 
 **Note:** If you use spring-boot with `@EnableAutoConfiguration` you no longer have to add the `ScenarioScopeConfiguration` explicitly and the scenario scope is available without further configuration.
 
-For an example for how to test REST endpoints in a spring-boot project using `MockMvc` check out the [`zuchini-examples-mockmvc` project](zuchini-examples-mockmvc/src/test/java/org/zuchini/examples/mockmvc/HelloFeatureTest.java).
+For an example for how to test REST endpoints in a spring-boot project using `MockMvc` check out the [`zuchini-examples-mockmvc` project](zuchini-examples-mockmvc/).
 
+```java
+@RunWith(SpringZuchini.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ZuchiniOptions(
+    featurePackages = "features/mockmvc",
+    stepDefinitionPackages = "org.zuchini.examples.mockmvc"
+)
+public class HelloSpringTest {
+}
+```
 
 ## IntelliJ integration
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,9 +44,8 @@
         <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
 
         <version.antlr>4.3</version.antlr>
-        <version.junit>4.11</version.junit>
+        <version.junit>4.12</version.junit>
         <version.hamcrest>1.3</version.hamcrest>
-        <version.spring>4.1.7.RELEASE</version.spring>
         <version.jackson>2.6.1</version.jackson>
     </properties>
 
@@ -153,21 +152,6 @@
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>3.0.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-context</artifactId>
-                <version>${version.spring}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-beans</artifactId>
-                <version>${version.spring}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-test</artifactId>
-                <version>${version.spring}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/zuchini-examples/pom.xml
+++ b/zuchini-examples/pom.xml
@@ -20,5 +20,6 @@
         <module>zuchini-examples-datatables</module>
         <module>zuchini-examples-hooks</module>
         <module>zuchini-examples-reporting</module>
+        <module>zuchini-examples-mockmvc</module>
     </modules>
 </project>

--- a/zuchini-examples/zuchini-examples-mockmvc/pom.xml
+++ b/zuchini-examples/zuchini-examples-mockmvc/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.zuchini.examples</groupId>
+        <artifactId>zuchini-examples</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>zuchini-examples-mockmvc</artifactId>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>1.5.7.RELEASE</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>1.5.7.RELEASE</version>
+                <configuration>
+                    <mainClass>org.zuchini.examples.mockmvc.Main</mainClass>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.zuchini</groupId>
+            <artifactId>zuchini-junit</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.zuchini</groupId>
+            <artifactId>zuchini-spring</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/zuchini-examples/zuchini-examples-mockmvc/src/main/java/org/zuchini/examples/mockmvc/Main.java
+++ b/zuchini-examples/zuchini-examples-mockmvc/src/main/java/org/zuchini/examples/mockmvc/Main.java
@@ -1,0 +1,11 @@
+package org.zuchini.examples.mockmvc;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Main {
+    public static void main(String[] args) {
+        SpringApplication.run(Main.class, args);
+    }
+}

--- a/zuchini-examples/zuchini-examples-mockmvc/src/main/java/org/zuchini/examples/mockmvc/provider/HelloResource.java
+++ b/zuchini-examples/zuchini-examples-mockmvc/src/main/java/org/zuchini/examples/mockmvc/provider/HelloResource.java
@@ -1,0 +1,34 @@
+package org.zuchini.examples.mockmvc.provider;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "/api/hello")
+public class HelloResource {
+    public static class Result {
+        private final String name;
+        private final String greeting;
+
+        public Result(String name, String greeting) {
+            this.name = name;
+            this.greeting = greeting;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getGreeting() {
+            return greeting;
+        }
+    }
+
+    @GetMapping(produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public Result hello(@RequestParam("name") String name) {
+        return new Result(name, "Hello " + name);
+    }
+}

--- a/zuchini-examples/zuchini-examples-mockmvc/src/test/java/org/zuchini/examples/mockmvc/HelloFeatureTest.java
+++ b/zuchini-examples/zuchini-examples-mockmvc/src/test/java/org/zuchini/examples/mockmvc/HelloFeatureTest.java
@@ -1,0 +1,16 @@
+package org.zuchini.examples.mockmvc;
+
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.zuchini.junit.ZuchiniOptions;
+import org.zuchini.spring.SpringZuchini;
+
+@RunWith(SpringZuchini.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ZuchiniOptions(featurePackages = {"features/mockmvc"},
+        stepDefinitionPackages = "org.zuchini.examples.mockmvc",
+        reportIndividualSteps = true)
+public class HelloFeatureTest {
+}

--- a/zuchini-examples/zuchini-examples-mockmvc/src/test/java/org/zuchini/examples/mockmvc/HelloResourceTest.java
+++ b/zuchini-examples/zuchini-examples-mockmvc/src/test/java/org/zuchini/examples/mockmvc/HelloResourceTest.java
@@ -1,0 +1,33 @@
+package org.zuchini.examples.mockmvc;
+
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+public class HelloResourceTest {
+    @Autowired
+    private MockMvc mvc;
+    @Test
+    public void shouldReturnGreeting() throws Exception {
+        mvc.perform(get("/api/hello")
+                .param("name", "World")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath(".name").value("World"))
+                .andExpect(jsonPath(".greeting").value("Hello World"));
+
+    }
+}

--- a/zuchini-examples/zuchini-examples-mockmvc/src/test/java/org/zuchini/examples/mockmvc/MockMvcSteps.java
+++ b/zuchini-examples/zuchini-examples-mockmvc/src/test/java/org/zuchini/examples/mockmvc/MockMvcSteps.java
@@ -1,7 +1,6 @@
 package org.zuchini.examples.mockmvc;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
@@ -9,7 +8,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.HeaderResultMatchers;
 import org.springframework.test.web.servlet.result.JsonPathResultMatchers;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.zuchini.annotations.Given;
@@ -24,9 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @Component
 @ScenarioScoped

--- a/zuchini-examples/zuchini-examples-mockmvc/src/test/java/org/zuchini/examples/mockmvc/MockMvcSteps.java
+++ b/zuchini-examples/zuchini-examples-mockmvc/src/test/java/org/zuchini/examples/mockmvc/MockMvcSteps.java
@@ -1,0 +1,106 @@
+package org.zuchini.examples.mockmvc;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.HeaderResultMatchers;
+import org.springframework.test.web.servlet.result.JsonPathResultMatchers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.zuchini.annotations.Given;
+import org.zuchini.annotations.Then;
+import org.zuchini.annotations.When;
+import org.zuchini.runner.tables.Datatable;
+import org.zuchini.spring.ScenarioScoped;
+
+import java.net.URI;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Component
+@ScenarioScoped
+public class MockMvcSteps {
+    @Autowired
+    private MockMvc mvc;
+
+    private HttpHeaders requestHeaders = new HttpHeaders();
+    private ResultActions resultActions;
+
+    private static MultiValueMap<String, String> toMultiValueMap(Datatable datatable) {
+        LinkedMultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+        for (List<String> header : datatable.getRows()) {
+            Iterator<String> iterator = header.iterator();
+            if (!iterator.hasNext()) {
+                throw new IllegalStateException("Name is required in datatable");
+            }
+
+            String headerName = iterator.next();
+            while (iterator.hasNext()) {
+                String headerValue = iterator.next();
+                if (!headerValue.isEmpty()) {
+                    map.add(headerName, headerValue);
+                }
+            }
+        }
+        return map;
+    }
+
+    @Given("^the following request headers:$")
+    public void givenRequestHeaders(Datatable datatable) {
+        requestHeaders.putAll(toMultiValueMap(datatable));
+    }
+
+    @When("^a (GET|POST|PUT|DELETE) request to \"([^\"]+)\" is executed$")
+    public void whenRequestIsExecuted(String method, String uri) throws Exception {
+        resultActions = mvc.perform(request(HttpMethod.valueOf(method), URI.create(uri))
+                .headers(requestHeaders));
+    }
+
+    @When("^a (GET|POST|PUT|DELETE) request to \"([^\"]+)\" is executed with the following parameters:$")
+    public void whenRequestIsExecuted(String method, String uri, Datatable datatable) throws Exception {
+        resultActions = mvc.perform(request(HttpMethod.valueOf(method), URI.create(uri))
+                .headers(requestHeaders)
+                .params(toMultiValueMap(datatable)));
+    }
+
+    @Then("^the response status is ([0-9]+)$")
+    public void responseStatusIs(int status) throws Exception {
+        resultActions.andExpect(status().is(status));
+    }
+
+    @Then("^the response body matches the following json paths:$")
+    public void responseMatchesJsonPath(Datatable datatable) throws Exception {
+        MultiValueMap<String, String> map = toMultiValueMap(datatable);
+        for (Map.Entry<String, List<String>> entry : map.entrySet()) {
+            String key = entry.getKey();
+            JsonPathResultMatchers jsonPath = jsonPath(key);
+            for (String value : entry.getValue()) {
+                resultActions.andExpect(jsonPath.value(value));
+            }
+        }
+    }
+
+    @Then("^the response contains the following headers:$")
+    public void responseHeadersContain(Datatable datatable) throws Exception {
+        MultiValueMap<String, String> map = toMultiValueMap(datatable);
+        HeaderResultMatchers header = header();
+        for (Map.Entry<String, List<String>> entry : map.entrySet()) {
+            String key = entry.getKey();
+            for (String value : entry.getValue()) {
+                resultActions.andExpect(header.string(key, value));
+            }
+        }
+    }
+
+}

--- a/zuchini-examples/zuchini-examples-mockmvc/src/test/resources/features/mockmvc/mvc.feature
+++ b/zuchini-examples/zuchini-examples-mockmvc/src/test/resources/features/mockmvc/mvc.feature
@@ -4,13 +4,18 @@ Feature: MockMvc
     Given the following request headers:
       | Accept | application/json |
 
-  Scenario: Simple request
+  Scenario Outline: Simple requests
     When a GET request to "/api/hello" is executed with the following parameters:
-      | name | World |
+      | name | <name> |
     Then the response status is 200
     And the response body matches the following json paths:
-      | .name     | World       |
-      | .greeting | Hello World |
+      | .name     | <name>       |
+      | .greeting | Hello <name> |
     And the response contains the following headers:
       | Content-Type | application/json;charset=UTF-8 |
+    Examples:
+      | name    |
+      | World   |
+      | Spring  |
+      | Zuchini |
 

--- a/zuchini-examples/zuchini-examples-mockmvc/src/test/resources/features/mockmvc/mvc.feature
+++ b/zuchini-examples/zuchini-examples-mockmvc/src/test/resources/features/mockmvc/mvc.feature
@@ -1,0 +1,16 @@
+Feature: MockMvc
+
+  Background: Common request headers
+    Given the following request headers:
+      | Accept | application/json |
+
+  Scenario: Simple request
+    When a GET request to "/api/hello" is executed with the following parameters:
+      | name | World |
+    Then the response status is 200
+    And the response body matches the following json paths:
+      | .name     | World       |
+      | .greeting | Hello World |
+    And the response contains the following headers:
+      | Content-Type | application/json;charset=UTF-8 |
+

--- a/zuchini-junit/src/test/java/org/zuchini/junit/helloworld/HelloWorldSteps.java
+++ b/zuchini-junit/src/test/java/org/zuchini/junit/helloworld/HelloWorldSteps.java
@@ -1,0 +1,28 @@
+package org.zuchini.junit.helloworld;
+
+import org.junit.Assert;
+import org.zuchini.annotations.Given;
+import org.zuchini.annotations.Then;
+import org.zuchini.annotations.When;
+
+public class HelloWorldSteps {
+    private String name;
+    private String output;
+
+    @Given("^the user name is '([^']+)'$")
+    public void userNameIs(String name) {
+        this.name = name;
+    }
+
+    @When("^the user clicks the hello button$")
+    public void clickTheButton() {
+        this.output = "Hello " + name;
+    }
+
+    @Then("^the output is '([^']+)'")
+    public void outputIs(String expectedOutput) {
+        Assert.assertEquals("Output should be", expectedOutput, output);
+    }
+
+
+}

--- a/zuchini-junit/src/test/java/org/zuchini/junit/helloworld/HelloWorldTest.java
+++ b/zuchini-junit/src/test/java/org/zuchini/junit/helloworld/HelloWorldTest.java
@@ -1,0 +1,10 @@
+package org.zuchini.junit.helloworld;
+
+import org.junit.runner.RunWith;
+import org.zuchini.junit.Zuchini;
+import org.zuchini.junit.ZuchiniOptions;
+
+@RunWith(Zuchini.class)
+@ZuchiniOptions(featurePackages = {"features/helloworld"}, stepDefinitionPackages = "org.zuchini.junit.helloworld", reportIndividualSteps = true)
+public class HelloWorldTest {
+}

--- a/zuchini-junit/src/test/resources/features/helloworld/helloworld.feature
+++ b/zuchini-junit/src/test/resources/features/helloworld/helloworld.feature
@@ -1,0 +1,6 @@
+Feature: Hello World
+
+  Scenario: Hello World
+    Given the user name is 'World'
+    When the user clicks the hello button
+    Then the output is 'Hello World'

--- a/zuchini-spring/pom.xml
+++ b/zuchini-spring/pom.xml
@@ -14,6 +14,7 @@
     <artifactId>zuchini-spring</artifactId>
 
     <properties>
+        <spring.version>4.1.7.RELEASE</spring.version>
     </properties>
 
     <dependencies>
@@ -30,14 +31,17 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-beans</artifactId>
+            <version>${spring.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/zuchini-spring/src/main/java/org/zuchini/spring/ScenarioScopeConfiguration.java
+++ b/zuchini-spring/src/main/java/org/zuchini/spring/ScenarioScopeConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import java.util.Collections;
 
 @Configuration
-public class SpringZuchiniConfiguration {
+public class ScenarioScopeConfiguration {
 
     @Bean
     public static SpringThreadLocalScope getSpringThreadLocalScope() {

--- a/zuchini-spring/src/main/java/org/zuchini/spring/ScopeExecutionListener.java
+++ b/zuchini-spring/src/main/java/org/zuchini/spring/ScopeExecutionListener.java
@@ -4,14 +4,27 @@ import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.TestContext;
 import org.springframework.test.context.TestExecutionListener;
+import org.zuchini.runner.Context;
 
-class ScopeExecutionListener implements TestExecutionListener {
+class ScopeExecutionListener implements TestExecutionListener, Context {
     private final BeanFactoryScope globalScope;
     private final BeanFactoryScope scenarioScope;
 
-    ScopeExecutionListener(BeanFactoryScope globalScope, BeanFactoryScope scenarioScope) {
+    public ScopeExecutionListener() {
+        this(new BeanFactoryScope(false), new BeanFactoryScope(true));
+    }
+
+    private ScopeExecutionListener(BeanFactoryScope globalScope, BeanFactoryScope scenarioScope) {
         this.globalScope = globalScope;
         this.scenarioScope = scenarioScope;
+    }
+
+    public BeanFactoryScope getGlobalScope() {
+        return globalScope;
+    }
+
+    public BeanFactoryScope getScenarioScope() {
+        return scenarioScope;
     }
 
     @Override

--- a/zuchini-spring/src/main/resources/META-INF/spring.factories
+++ b/zuchini-spring/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.zuchini.spring.ScenarioScopeConfiguration

--- a/zuchini-spring/src/test/java/org/zuchini/spring/cukes/cukes/CukesSpringTest.java
+++ b/zuchini-spring/src/test/java/org/zuchini/spring/cukes/cukes/CukesSpringTest.java
@@ -4,11 +4,11 @@ import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.zuchini.junit.ZuchiniOptions;
 import org.zuchini.spring.SpringZuchini;
-import org.zuchini.spring.SpringZuchiniConfiguration;
+import org.zuchini.spring.ScenarioScopeConfiguration;
 
 @RunWith(SpringZuchini.class)
 @ZuchiniOptions(featurePackages = {"features/cukes"}, stepDefinitionPackages = "org.zuchini.spring.cukes",
         reportIndividualSteps = true, listeners = {SpringAutowiredRunListener.class})
-@ContextConfiguration(classes = {SpringZuchiniConfiguration.class, CukesConfiguration.class})
+@ContextConfiguration(classes = {ScenarioScopeConfiguration.class, CukesConfiguration.class})
 public class CukesSpringTest {
 }

--- a/zuchini-spring/src/test/java/org/zuchini/spring/cukes/cukes/CukesSteps.java
+++ b/zuchini-spring/src/test/java/org/zuchini/spring/cukes/cukes/CukesSteps.java
@@ -1,7 +1,7 @@
 package org.zuchini.spring.cukes.cukes;
 
 import org.junit.Assert;
-import org.junit.internal.AssumptionViolatedException;
+import org.junit.AssumptionViolatedException;
 import org.springframework.stereotype.Component;
 import org.zuchini.annotations.Given;
 import org.zuchini.annotations.Then;


### PR DESCRIPTION
 - Simplified SpringZuchini runner
 - Renamed SpringZuchiniConfiguration to ScenarioScopeConfiguration
 - ScenarioScopeConfiguration is automatically detected with EnableAutoConfiguration
 - No more version conflict with spring by using same version property as in spring-boot-dependencies